### PR TITLE
fix: TypeScript define issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "exports": {
     "module": "./dist/index.esm.js",
     "import": "./dist/index.mjs",
-    "require": "./dist/index.cjs"
+    "require": "./dist/index.cjs",
+    "types": "./dist/index.d.ts"
   },
   "scripts": {
     "build": "bunchee --no-external --dts",


### PR DESCRIPTION
Missing type define in Node.js 20
add exports.types into package.json